### PR TITLE
Improve set_dot performance for CanonicalVector

### DIFF
--- a/examples/maxcut.jl
+++ b/examples/maxcut.jl
@@ -16,23 +16,24 @@ function maxcut_objective(weights)
     return L / 4
 end
 
+function maxcut_set(N; sparse = true, T = Float64)
+    cone = MOI.PositiveSemidefiniteConeTriangle(N)
+    factors = LRO.TriangleVectorization.(
+        LRO.positive_semidefinite_factorization.(e_i.(T, 1:N, N; sparse)),
+    )
+    return LRO.SetDotProducts{LRO.WITH_SET}(cone, factors)
+end
+
 function maxcut(weights, solver; sparse = true)
     T = float(eltype(weights))
     N = LinearAlgebra.checksquare(weights)
     model = GenericModel{T}(solver)
     LRO.Bridges.add_all_bridges(backend(model).optimizer, T)
-    cone = MOI.PositiveSemidefiniteConeTriangle(N)
-    factors = LRO.TriangleVectorization.(
-        LRO.positive_semidefinite_factorization.(e_i.(T, 1:N, N; sparse)),
-    )
-    set = LRO.SetDotProducts{LRO.WITH_SET}(cone, factors)
-    @variable(
-        model,
-        dot_prod_set[1:(length(factors)+MOI.dimension(cone))] in set
-    )
-    dot_prod = dot_prod_set[1:length(factors)]
+    set = maxcut_set(N; sparse, T)
+    @variable(model, dot_prod_set[1:MOI.dimension(set)] in set)
+    dot_prod = dot_prod_set[1:length(set.vectors)]
     X = reshape_vector(
-        dot_prod_set[length(factors) .+ (1:MOI.dimension(cone))],
+        dot_prod_set[length(set.vectors) .+ (1:MOI.dimension(set.set))],
         SymmetricMatrixShape(N),
     )
     @objective(model, Max, dot(maxcut_objective(weights), X))

--- a/perf/set_dot.jl
+++ b/perf/set_dot.jl
@@ -1,0 +1,17 @@
+include(joinpath(dirname(@__DIR__), "examples", "maxcut.jl"))
+
+# Important for Dualization
+function bench_set_dot(n)
+    T = Float64
+    set = maxcut_set(n; T)
+    d = MOI.dimension(set)
+    x = MOI.Utilities.CanonicalVector{T}(div(n, 2), d)
+    y = MOI.Utilities.CanonicalVector{T}(2n, d)
+    @btime MOI.Utilities.set_dot($x, $x, $set)
+    @btime MOI.Utilities.set_dot($y, $y, $set)
+end
+
+# Expected:
+#   3.437 ns (0 allocations: 0 bytes)
+#   6.182 ns (0 allocations: 0 bytes)
+bench_set_dot(1000)

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -126,8 +126,15 @@ function MOI.Utilities.set_dot(
     set::Union{SetDotProducts{WITH_SET},LinearCombinationInSet{WITH_SET}},
 )
     n = length(set.vectors)
-    return LinearAlgebra.dot(x[1:n], y[1:n]) +
-           MOI.Utilities.set_dot(x[(n+1):end], y[(n+1):end], set.set)
+    # MOI defines a custom `view(::CanonicalVector, ::AbstractUnitRange)`
+    # so we should use `view` in order to keep the `CanonicalVector`
+    # structure.
+    return LinearAlgebra.dot(view(x, 1:n), view(y, 1:n)) +
+           MOI.Utilities.set_dot(
+            view(x, (n+1):length(x)),
+            view(y, (n+1):length(y)),
+            set.set,
+        )
 end
 
 function MOI.Utilities.dot_coefficients(

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -131,10 +131,10 @@ function MOI.Utilities.set_dot(
     # structure.
     return LinearAlgebra.dot(view(x, 1:n), view(y, 1:n)) +
            MOI.Utilities.set_dot(
-            view(x, (n+1):length(x)),
-            view(y, (n+1):length(y)),
-            set.set,
-        )
+        view(x, (n+1):length(x)),
+        view(y, (n+1):length(y)),
+        set.set,
+    )
 end
 
 function MOI.Utilities.dot_coefficients(


### PR DESCRIPTION
Benchmark before
```
  835.672 μs (12 allocations: 7.65 MiB)
  849.430 μs (12 allocations: 7.65 MiB)
```
After
```
  3.437 ns (0 allocations: 0 bytes)
  6.182 ns (0 allocations: 0 bytes)
```