### PR TITLE
Add buffered model

### DIFF
--- a/src/LowRankOpt.jl
+++ b/src/LowRankOpt.jl
@@ -17,6 +17,7 @@ include("distance_to_set.jl")
 include("Test/Test.jl")
 include("Bridges/Bridges.jl")
 
+include("solution.jl")
 include("model.jl")
 include("buffer.jl")
 include("schur.jl")

--- a/src/LowRankOpt.jl
+++ b/src/LowRankOpt.jl
@@ -18,6 +18,7 @@ include("Test/Test.jl")
 include("Bridges/Bridges.jl")
 
 include("model.jl")
+include("buffer.jl")
 include("schur.jl")
 include("MOI_wrapper.jl")
 include("BurerMonteiro.jl")

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -268,7 +268,9 @@ function _add_constraints(
             A[lmi_id, k] = _MatrixBuilder{T}(d)
         end
         for row in eachindex(func.constants)
-            _add!(A[lmi_id, 1], row, func.constants[row], set)
+            if !iszero(func.constants[row])
+                _add!(A[lmi_id, 1], row, func.constants[row], set)
+            end
         end
         for term in func.terms
             scalar = term.scalar_term

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -339,7 +339,12 @@ function MOI.copy_to(
     vis_src = MOI.get(src, MOI.ListOfVariableIndices())
     # Just to throw a nice error saying we don't support such attributes
     # Filter them out since we already took care of them
-    no_obj = MOI.Utilities.ModelFilter(attr -> !(attr isa MOI.ObjectiveFunction || attr isa MOI.ObjectiveSense), src)
+    no_obj = MOI.Utilities.ModelFilter(
+        attr -> !(
+            attr isa MOI.ObjectiveFunction || attr isa MOI.ObjectiveSense
+        ),
+        src,
+    )
     # We error for the rest. In the future, we should also take care of starting values
     MOI.Utilities.pass_attributes(dest, no_obj, index_map)
     MOI.Utilities.pass_attributes(dest, src, index_map, vis_src)

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -1,4 +1,4 @@
-mutable struct BufferedModelForSchur{T,C<:AbstractMatrix{T},A<:AbstractMatrix{T},JB,JTB,SB} <: NLPModels.AbstractNLPModel{T,Vector{T}}
+mutable struct BufferedModelForSchur{T,C<:AbstractMatrix{T},A<:AbstractMatrix{T},JB,JTB,SB} <: AbstractModel{T}
     model::Model{T,C,A}
     meta::NLPModels.NLPModelMeta{T,Vector{T}}
     jprod_buffer::JB
@@ -20,14 +20,6 @@ num_scalars(model::BufferedModelForSchur) = num_scalars(model.model)
 num_matrices(model::BufferedModelForSchur) = num_matrices(model.model)
 matrix_indices(model::BufferedModelForSchur) = matrix_indices(model.model)
 side_dimension(model::BufferedModelForSchur, i) = side_dimension(model.model, i)
-cons_constant(model::BufferedModelForSchur) = cons_constant(model.model)
-
-NLPModels.grad(model::BufferedModelForSchur, ::Type{ScalarIndex}) = NLPModels.grad(model.model, ScalarIndex)
-NLPModels.grad(model::BufferedModelForSchur, i::MatrixIndex) = NLPModels.grad(model.model, i)
-NLPModels.jac(model::BufferedModelForSchur, j::Integer, ::Type{ScalarIndex}) = NLPModels.jac(model.model, j, ScalarIndex)
-norm_jac(model::BufferedModelForSchur, i::MatrixIndex) = norm_jac(model.model, i)
-
-errors(model::BufferedModelForSchur, x; kws...) = errors(model.model, x; kws...)
 
 #######################
 ###### Objective ######
@@ -41,14 +33,25 @@ function dual_obj(model::BufferedModelForSchur, y::AbstractVector)
     return dual_obj(model.model, y)
 end
 
+NLPModels.grad(model::BufferedModelForSchur, ::Type{ScalarIndex}) = NLPModels.grad(model.model, ScalarIndex)
+NLPModels.grad(model::BufferedModelForSchur, i::MatrixIndex) = NLPModels.grad(model.model, i)
+
+#########################
+###### Constraints ######
+#########################
+
+cons_constant(model::BufferedModelForSchur) = cons_constant(model.model)
+NLPModels.jac(model::BufferedModelForSchur, j::Integer, ::Type{ScalarIndex}) = NLPModels.jac(model.model, j, ScalarIndex)
+norm_jac(model::BufferedModelForSchur, i::MatrixIndex) = norm_jac(model.model, i)
+
+errors(model::BufferedModelForSchur, x; kws...) = errors(model.model, x; kws...)
+
 #######################
 ###### J product ######
 #######################
 
-function buffer_for_jprod(model::Model{T}) where {T}
-    return SparseArrays.SparseMatrixCSC{T,Int64}[
-        buffer_for_jprod(model, i) for i in matrix_indices(model)
-    ]
+function jprod!(model, x, v, Jv, ::Type{ScalarIndex})
+    return jprod!(model.model, x, v, Jv, ScalarIndex)
 end
 
 function _add_vec!(_, _, _, _, offset, ::FillArrays.Zeros)
@@ -92,6 +95,12 @@ function buffer_for_jprod(model::Model{T}, i::MatrixIndex) where {T}
     return A
 end
 
+function buffer_for_jprod(model::Model{T}) where {T}
+    return SparseArrays.SparseMatrixCSC{T,Int64}[
+        buffer_for_jprod(model, i) for i in matrix_indices(model)
+    ]
+end
+
 _vec(x::AbstractVector) = x
 _vec(x::AbstractArray) = UnsafeArrays.uview(x, :)
 _vec(x::Base.ReshapedArray) = _vec(parent(x))
@@ -119,18 +128,6 @@ function add_jprod!(
     i::MatrixIndex,
 )
     return _add_jprod!(V, Jv, model.jprod_buffer[i.value])
-end
-
-function NLPModels.jprod!(model::BufferedModelForSchur, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
-    return NLPModels.jprod!(model.model, x, v, Jv, model.jprod_buffer)
-end
-
-function NLPModels.cons!(
-    model::BufferedModelForSchur,
-    x::AbstractVector,
-    cx::AbstractVector,
-)
-    return NLPModels.cons!(model.model, x, cx, model.jprod_buffer)
 end
 
 ########################
@@ -170,13 +167,40 @@ function NLPModels.jtprod!(
 )
     jtprod!(model, y, vJ[ScalarIndex], ScalarIndex)
     for mat_idx in matrix_indices(model)
-        i = mat_idx.value
-        vJ[mat_idx] .= jtprod!(model, y, buffer[i], mat_idx)
+        vJ[mat_idx] .= jtprod!(model, y, mat_idx)
     end
 end
 
 _zero!(A::FillArrays.Zeros) = A
 _zero!(A::SparseArrays.SparseMatrixCSC) = fill!(SparseArrays.nonzeros(A), 0.0)
+
+# Computes `A .+= B * α`
+function _add_mul!(
+    A::SparseArrays.SparseMatrixCSC,
+    ::FillArrays.Zeros,
+    _,
+)
+    return A
+end
+
+function _add_mul!(
+    A::SparseArrays.SparseMatrixCSC,
+    B::SparseArrays.SparseMatrixCSC,
+    α,
+)
+    for col in axes(A, 2)
+        range_A = SparseArrays.nzrange(A, col)
+        it_A = iterate(range_A)
+        for k in SparseArrays.nzrange(B, col)
+            row_B = SparseArrays.rowvals(B)[k]
+            while SparseArrays.rowvals(A)[it_A[1]] < row_B
+                it_A = iterate(range_A, it_A[2])
+            end
+            @assert row_B == SparseArrays.rowvals(A)[it_A[1]]
+            SparseArrays.nonzeros(A)[it_A[1]] += SparseArrays.nonzeros(B)[k] * α
+        end
+    end
+end
 
 function jtprod!(model::Model, y, buffer, mat_idx::MatrixIndex)
     _zero!(buffer)

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -259,6 +259,9 @@ function dual_cons!(
     return dual_cons!(model.model, y, res, ScalarIndex)
 end
 
+# TODO If we rename `dual_cons!` to `unsafe_dual_cons`,
+#      we can remove the `copy` and remplace `-B` with a mutation
+
 # Note that we can't use `-` because of https://github.com/JuliaArrays/FillArrays.jl/issues/412
 _sub(A::FillArrays.Zeros, ::FillArrays.Zeros) = A
 _sub(A::AbstractArray, ::FillArrays.Zeros) = copy(A)

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -1,0 +1,203 @@
+mutable struct BufferedModelForSchur{T,C<:AbstractMatrix{T},A<:AbstractMatrix{T},JB,JTB,SB} <: NLPModels.AbstractNLPModel{T,Vector{T}}
+    model::Model{T,C,A}
+    meta::NLPModels.NLPModelMeta{T,Vector{T}}
+    jprod_buffer::JB
+    jtprod_buffer::JTB
+    schur_buffer::SB
+end
+
+function BufferedModelForSchur(model, datasparsity)
+    return BufferedModelForSchur(
+        model,
+        model.meta,
+        buffer_for_jprod(model),
+        buffer_for_jtprod(model),
+        buffer_for_schur_complement(model, datasparsity),
+    )
+end
+
+num_scalars(model::BufferedModelForSchur) = num_scalars(model.model)
+num_matrices(model::BufferedModelForSchur) = num_matrices(model.model)
+matrix_indices(model::BufferedModelForSchur) = matrix_indices(model.model)
+side_dimension(model::BufferedModelForSchur, i) = side_dimension(model.model, i)
+cons_constant(model::BufferedModelForSchur) = cons_constant(model.model)
+
+NLPModels.grad(model::BufferedModelForSchur, ::Type{ScalarIndex}) = NLPModels.grad(model.model, ScalarIndex)
+NLPModels.grad(model::BufferedModelForSchur, i::MatrixIndex) = NLPModels.grad(model.model, i)
+NLPModels.jac(model::BufferedModelForSchur, j::Integer, ::Type{ScalarIndex}) = NLPModels.jac(model.model, j, ScalarIndex)
+norm_jac(model::BufferedModelForSchur, i::MatrixIndex) = norm_jac(model.model, i)
+
+errors(model::BufferedModelForSchur, x; kws...) = errors(model.model, x; kws...)
+
+#######################
+###### Objective ######
+#######################
+
+function NLPModels.obj(model::BufferedModelForSchur, x::AbstractVector)
+    return NLPModels.obj(model.model, x)
+end
+
+function dual_obj(model::BufferedModelForSchur, y::AbstractVector)
+    return dual_obj(model.model, y)
+end
+
+#######################
+###### J product ######
+#######################
+
+function buffer_for_jprod(model::Model{T}) where {T}
+    return SparseArrays.SparseMatrixCSC{T,Int64}[
+        buffer_for_jprod(model, i) for i in matrix_indices(model)
+    ]
+end
+
+function _add_vec!(_, _, _, _, offset, ::FillArrays.Zeros)
+    return offset
+end
+
+function _add_vec!(I, J, V, j, offset, A::SparseArrays.SparseMatrixCSC)
+    Ai, Av = SparseArrays.findnz(A[:])
+    K = offset .+ eachindex(Ai)
+    I[K] = Ai
+    J[K] .= j
+    V[K] = Av
+    return offset + length(Ai)
+end
+
+# `SparseMatrixCSC` is stored with an offset by column.
+# This means that getting view `view(A, :, I)` can be handles efficently,
+# these give `SparseMatrixCSCView` (if `I` is a `UnitRange`) and
+# `SparseMatrixCSCColumnSubset` otherwise.
+# In `schur.jl`, we therefore get a `SparseMatrixCSCColumnSubset`.
+# Since we want to use subsets of constraint indices, we use the columns
+# of `A` for constraint indices and the rows of `A` for matrix indices.
+function buffer_for_jprod(model::Model{T}, i::MatrixIndex) where {T}
+    nnz = sum(1:model.meta.ncon; init = 0) do j
+        return _nnz(model.A[i.value, j])
+    end
+    I = zeros(Int64, nnz)
+    J = zeros(Int64, nnz)
+    V = zeros(T, nnz)
+    offset = 0
+    for j in 1:model.meta.ncon
+        offset = _add_vec!(I, J, V, j, offset, model.A[i.value, j])
+    end
+    A = SparseArrays.sparse(
+        I,
+        J,
+        V,
+        side_dimension(model, i)^2,
+        model.meta.ncon,
+    )
+    return A
+end
+
+_vec(x::AbstractVector) = x
+_vec(x::AbstractArray) = UnsafeArrays.uview(x, :)
+_vec(x::Base.ReshapedArray) = _vec(parent(x))
+
+function _add_jprod!(V, Jv::AbstractArray{T}, A) where {T}
+    return LinearAlgebra.mul!(Jv, A', _vec(V), true, true)
+end
+
+function add_sub_jprod!(
+    model::BufferedModelForSchur,
+    i::MatrixIndex,
+    V::AbstractMatrix,
+    Jv::AbstractVector,
+    I,
+)
+    # `view(cache, I)` would be terribly slow, only the number of elements of `I` matter here
+    A = model.jprod_buffer[i.value]
+    return _add_jprod!(V, Jv, view(A, :, I))
+end
+
+function add_jprod!(
+    model::BufferedModelForSchur,
+    V::AbstractMatrix,
+    Jv::AbstractVector,
+    i::MatrixIndex,
+)
+    return _add_jprod!(V, Jv, model.jprod_buffer[i.value])
+end
+
+function NLPModels.jprod!(model::BufferedModelForSchur, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
+    return NLPModels.jprod!(model.model, x, v, Jv, model.jprod_buffer)
+end
+
+function NLPModels.cons!(
+    model::BufferedModelForSchur,
+    x::AbstractVector,
+    cx::AbstractVector,
+)
+    return NLPModels.cons!(model.model, x, cx, model.jprod_buffer)
+end
+
+########################
+###### Jᵀ product ######
+########################
+
+function jtprod!(model::BufferedModelForSchur, y::AbstractVector, vJ::AbstractVector, ::Type{ScalarIndex})
+    jtprod!(model.model, y, vJ, ScalarIndex)
+end
+
+function buffer_for_jtprod(model::Model)
+    if iszero(num_matrices(model))
+        return
+    end
+    return map(Base.Fix1(buffer_for_jtprod, model), matrix_indices(model))
+end
+
+_merge_sparsity(A::SparseArrays.SparseMatrixCSC, B::SparseArrays.SparseMatrixCSC) = abs.(A) + abs.(B)
+_merge_sparsity(::FillArrays.Zeros, B::SparseArrays.SparseMatrixCSC) = B
+_merge_sparsity(A::SparseArrays.SparseMatrixCSC, ::FillArrays.Zeros) = A
+_merge_sparsity(A::FillArrays.Zeros, ::FillArrays.Zeros) = A
+
+function buffer_for_jtprod(model::Model{T}, mat_idx::MatrixIndex) where {T}
+    if iszero(model.meta.ncon)
+        d = side_dimension(model, mat_idx)
+        return FillArrays.Zeros{T}(d, d)
+    end
+    # FIXME: at some point, switch to dense
+    return reduce(_merge_sparsity, model.A[mat_idx.value, j] for j in 1:model.meta.ncon)
+end
+
+function NLPModels.jtprod!(
+    model::BufferedModelForSchur,
+    _::AbstractVector,
+    y::AbstractVector,
+    vJ::AbstractVector,
+)
+    jtprod!(model, y, vJ[ScalarIndex], ScalarIndex)
+    for mat_idx in matrix_indices(model)
+        i = mat_idx.value
+        vJ[mat_idx] .= jtprod!(model, y, buffer[i], mat_idx)
+    end
+end
+
+_zero!(A::FillArrays.Zeros) = A
+_zero!(A::SparseArrays.SparseMatrixCSC) = fill!(SparseArrays.nonzeros(A), 0.0)
+
+function jtprod!(model::Model, y, buffer, mat_idx::MatrixIndex)
+    _zero!(buffer)
+    for j in eachindex(y)
+        _add_mul!(buffer, model.A[mat_idx.value, j], y[j])
+    end
+    return buffer
+end
+
+function jtprod!(model::BufferedModelForSchur, y, mat_idx::MatrixIndex)
+    return jtprod!(model.model, y, model.jtprod_buffer[mat_idx.value], mat_idx)
+end
+
+function dual_cons!(model::BufferedModelForSchur, y::AbstractVector, res, ::Type{ScalarIndex})
+    return dual_cons!(model.model, y, res, ScalarIndex)
+end
+
+function dual_cons!(
+    model::BufferedModelForSchur,
+    y::AbstractVector,
+    i::MatrixIndex,
+)
+    return model.model.C[i.value] - jtprod!(model, y, i)
+end

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -209,7 +209,7 @@ function NLPModels.jtprod!(
     end
 end
 
-_zero!(A::FillArrays.Zeros) = (@show @__LINE__; A)
+_zero!(A::FillArrays.Zeros) = A
 _zero!(A::SparseArrays.SparseMatrixCSC) = fill!(SparseArrays.nonzeros(A), 0.0)
 
 # Computes `A .+= B * α`

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -260,7 +260,9 @@ function dual_cons!(
 end
 
 # Note that we can't use `-` because of https://github.com/JuliaArrays/FillArrays.jl/issues/412
+_sub(A::FillArrays.Zeros, ::FillArrays.Zeros) = A
 _sub(A::AbstractArray, ::FillArrays.Zeros) = copy(A)
+_sub(::FillArrays.Zeros, B::AbstractArray) = -B
 _sub(A::AbstractArray, B::AbstractArray) = A - B
 
 function dual_cons!(

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -4,7 +4,7 @@
 Return [the 6 standard DIMACS errors](https://plato.asu.edu/dimacs/node3.html).
 """
 function errors(
-    model::Model,
+    model::AbstractModel,
     x;
     y = nothing,
     primal_err = NLPModels.cons(model, x),

--- a/src/model.jl
+++ b/src/model.jl
@@ -60,7 +60,8 @@ The fields of the `struct` as related to the arrays of the above formulation as 
 * The matrix ``C_i`` is given by `C[i]`.
 * The matrix ``A_{i,j}`` is given by `A[i,j]`.
 """
-mutable struct Model{T,C<:AbstractMatrix{T},A<:AbstractMatrix{T}} <: AbstractModel{T}
+mutable struct Model{T,C<:AbstractMatrix{T},A<:AbstractMatrix{T}} <:
+               AbstractModel{T}
     meta::NLPModels.NLPModelMeta{T,Vector{T}}
     dim::Dimensions
     C::Vector{C}
@@ -152,7 +153,12 @@ end
 
 dual_obj(model::Model, y::AbstractVector) = LinearAlgebra.dot(model.b, y)
 
-function jtprod!(model::Model, y::AbstractVector, vJ::AbstractVector, ::Type{ScalarIndex})
+function jtprod!(
+    model::Model,
+    y::AbstractVector,
+    vJ::AbstractVector,
+    ::Type{ScalarIndex},
+)
     return LinearAlgebra.mul!(vJ, model.C_lin', y)
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -6,6 +6,7 @@ import NLPModels
 import UnsafeArrays
 
 abstract type AbstractModel{T} <: NLPModels.AbstractNLPModel{T,Vector{T}} end
+Base.broadcastable(model::AbstractModel) = Ref(model)
 
 function NLPModels.cons!(
     model::AbstractModel,

--- a/src/schur.jl
+++ b/src/schur.jl
@@ -69,7 +69,12 @@ function buffer_for_schur_complement(model::Model{T}, κ) where {T}
     return AW, WAW, σ, last_dense
 end
 
-function add_schur_complement!(model::BufferedModelForSchur, W, ::Type{MatrixIndex}, H)
+function add_schur_complement!(
+    model::BufferedModelForSchur,
+    W,
+    ::Type{MatrixIndex},
+    H,
+)
     for i in matrix_indices(model)
         add_schur_complement!(model, i, W[i], H)
     end
@@ -144,7 +149,12 @@ function add_schur_complement!(
     return H
 end
 
-function add_schur_complement!(model::BufferedModelForSchur, w, ::Type{ScalarIndex}, H)
+function add_schur_complement!(
+    model::BufferedModelForSchur,
+    w,
+    ::Type{ScalarIndex},
+    H,
+)
     H .+= model.model.C_lin * SparseArrays.spdiagm(w) * model.model.C_lin'
     return H
 end
@@ -166,20 +176,10 @@ end
 # [HKS24, (5b)]
 # Returns the matrix equal to the sum, for each equation, of
 # ⟨A_i, WA(y)W⟩
-function eval_schur_complement!(
-    model::BufferedModelForSchur,
-    W,
-    y,
-    result,
-)
+function eval_schur_complement!(model::BufferedModelForSchur, W, y, result)
     fill!(result, zero(eltype(result)))
     for i in matrix_indices(model)
-        add_jprod!(
-            model,
-            W[i] * jtprod!(model, y, i) * W[i],
-            result,
-            i,
-        )
+        add_jprod!(model, W[i] * jtprod!(model, y, i) * W[i], result, i)
     end
     result .+= model.model.C_lin * (W[ScalarIndex] .* (model.model.C_lin' * y))
     return result

--- a/src/schur.jl
+++ b/src/schur.jl
@@ -66,38 +66,36 @@ function buffer_for_schur_complement(model::Model{T}, κ) where {T}
           for dim in model.msizes]
     WAW = copy.(AW)
 
-    return buffer_for_jprod(model), AW, WAW, σ, last_dense
+    return AW, WAW, σ, last_dense
 end
 
-function add_schur_complement!(model::Model, W, ::Type{MatrixIndex}, H, buffer)
+function add_schur_complement!(model::BufferedModelForSchur, W, ::Type{MatrixIndex}, H)
     for i in matrix_indices(model)
-        add_schur_complement!(model, i, W[i], H, buffer)
+        add_schur_complement!(model, i, W[i], H)
     end
     return H
 end
 
 # /!\ W needs to be symmetric
 function add_schur_complement!(
-    model::Model,
+    model::BufferedModelForSchur,
     mat_idx::MatrixIndex,
     W::AbstractMatrix{T},
     H,
-    buffer,
 ) where {T}
-    jprod_buffer, AW, WAW, σ, last_dense = buffer
-    buf = jprod_buffer[mat_idx]
+    AW, WAW, σ, last_dense = model.schur_buffer
     ilmi = mat_idx.value
     n = model.meta.ncon
 
     for ii in axes(H, 1)
         i = σ[ii, ilmi]
-        Ai = model.A[ilmi, i]
+        Ai = model.model.A[ilmi, i]
         if _nnz(Ai) > 0
             if ii <= last_dense[ilmi]
                 LinearAlgebra.mul!(AW[ilmi], W, Ai)
                 LinearAlgebra.mul!(WAW[ilmi], AW[ilmi], W)
                 I = view(σ, ii:n, ilmi)
-                add_sub_jprod!(model, mat_idx, WAW[ilmi], view(H, I, i), I, buf)
+                add_sub_jprod!(model, mat_idx, WAW[ilmi], view(H, I, i), I)
                 for jj in (ii+1):n
                     j = σ[jj, ilmi]
                     H[i, j] = H[j, i]
@@ -106,7 +104,7 @@ function add_schur_complement!(
                 if _nnz(Ai) > 1
                     @inbounds for jj in ii:n
                         j = σ[jj, ilmi]
-                        Aj = model.A[ilmi, j]
+                        Aj = model.model.A[ilmi, j]
                         if !iszero(_nnz(Aj))
                             ttt = _dot(Ai, Aj, W)
                             H[i, j] += ttt
@@ -121,7 +119,7 @@ function add_schur_complement!(
                     vvvi = only(SparseArrays.nonzeros(Ai))
                     @inbounds for jj in ii:n
                         j = σ[jj, ilmi]
-                        Ajjj = model.A[ilmi, j]
+                        Ajjj = model.model.A[ilmi, j]
                         # As we sort the matrices in decreasing `nnz` order,
                         # the rest of matrices is either zero or have only
                         # one entry
@@ -146,18 +144,18 @@ function add_schur_complement!(
     return H
 end
 
-function add_schur_complement!(model::Model, w, ::Type{ScalarIndex}, H)
-    H .+= model.C_lin * SparseArrays.spdiagm(w) * model.C_lin'
+function add_schur_complement!(model::BufferedModelForSchur, w, ::Type{ScalarIndex}, H)
+    H .+= model.model.C_lin * SparseArrays.spdiagm(w) * model.model.C_lin'
     return H
 end
 
 # [HKS24, (5b)]
 # Returns the matrix equal to the sum, for each equation, of
 # ⟨A_i, WA_jW⟩
-function schur_complement!(model::Model, W::AbstractVector, H, buffer)
+function schur_complement!(model::BufferedModelForSchur, W::AbstractVector, H)
     fill!(H, zero(eltype(H)))
     if num_matrices(model) > 0
-        add_schur_complement!(model, W, MatrixIndex, H, buffer)
+        add_schur_complement!(model, W, MatrixIndex, H)
     end
     if num_scalars(model) > 0
         add_schur_complement!(model, W[ScalarIndex], ScalarIndex, H)
@@ -169,23 +167,20 @@ end
 # Returns the matrix equal to the sum, for each equation, of
 # ⟨A_i, WA(y)W⟩
 function eval_schur_complement!(
-    result,
-    model::Model,
+    model::BufferedModelForSchur,
     W,
     y,
-    jprod_buffer,
-    jtprod_buffer,
+    result,
 )
     fill!(result, zero(eltype(result)))
     for i in matrix_indices(model)
         add_jprod!(
             model,
-            i,
-            W[i] * jtprod!(jtprod_buffer[i.value], model, i, y) * W[i],
+            W[i] * jtprod!(model, y, i) * W[i],
             result,
-            jprod_buffer[i],
+            i,
         )
     end
-    result .+= model.C_lin * (W[ScalarIndex] .* (model.C_lin' * y))
+    result .+= model.model.C_lin * (W[ScalarIndex] .* (model.model.C_lin' * y))
     return result
 end

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -1,0 +1,90 @@
+struct Dimensions
+    num_scalars::Int64
+    side_dimensions::Vector{Int64}
+    offsets::Vector{Int64}
+end
+
+num_matrices(d::Dimensions) = length(d.side_dimensions)
+Base.length(d::Dimensions) = d.offsets[end]
+
+struct ScalarIndex
+    value::Int64
+end
+
+struct MatrixIndex
+    value::Int64
+end
+Base.broadcastable(i::MatrixIndex) = Ref(i)
+
+abstract type AbstractSolution{T} <: AbstractVector{T} end
+
+function Base.getindex(
+    s::AbstractSolution,
+    i::Union{Type{ScalarIndex},MatrixIndex},
+)
+    return view(s, i)
+end
+
+struct VectorizedSolution{T} <: AbstractSolution{T}
+    x::Vector{T}
+    dim::Dimensions
+end
+
+function LinearAlgebra.dot(x::VectorizedSolution, z::VectorizedSolution)
+    return LinearAlgebra.dot(x.x, z.x)
+end
+
+num_matrices(x::VectorizedSolution) = num_matrices(x.dim)
+
+Base.similar(s::VectorizedSolution) = VectorizedSolution(similar(s.x), s.dim)
+
+Base.size(s::VectorizedSolution) = (length(s.dim),)
+
+function Base.to_index(s::VectorizedSolution, ::Type{ScalarIndex})
+    return Base.OneTo(s.dim.num_scalars)
+end
+
+function Base.to_index(s::VectorizedSolution, mi::MatrixIndex)
+    i = mi.value
+    return (1+s.dim.offsets[i]):s.dim.offsets[i+1]
+end
+
+function Base.view(s::VectorizedSolution, ::Type{ScalarIndex})
+    return view(s.x, Base.to_index(s, ScalarIndex))
+end
+
+# `s[i] .= ...` calleds `copyto!(view(s, i), Broadcasted(...))`
+function Base.view(s::VectorizedSolution, i::MatrixIndex)
+    v = view(s.x, Base.to_index(s, i))
+    dim = s.dim.side_dimensions[i.value]
+    X = reshape(v, dim, dim)
+    return X
+end
+
+Base.setindex!(s::VectorizedSolution, v, i::Integer) = setindex!(s.x, v, i)
+Base.getindex(s::VectorizedSolution, i::Integer) = getindex(s.x, i)
+
+struct ShapedSolution{T,MT<:AbstractMatrix{T}} <: AbstractSolution{T}
+    scalars::Vector{T}
+    matrices::Vector{MT}
+end
+
+function Base.size(s::ShapedSolution)
+    return (length(s.scalars) + sum(length, s.matrices, init = 0),)
+end
+num_matrices(s::ShapedSolution) = length(s.matrices)
+
+function LinearAlgebra.norm2(s::ShapedSolution{T}) where {T}
+    # `LinearAlgebra.generic_norm2` starts by computing the ∞ norm and do a rescaling, we don't do that here
+    return √(LinearAlgebra.dot(s, s))
+end
+
+function LinearAlgebra.dot(a::ShapedSolution{T}, b::ShapedSolution{T}) where {T}
+    return LinearAlgebra.dot(a.scalars, b.scalars) +
+           sum(eachindex(a.matrices); init = zero(T)) do i
+        return LinearAlgebra.dot(a.matrices[i], b.matrices[i])
+    end
+end
+
+Base.view(s::ShapedSolution, ::Type{ScalarIndex}) = s.scalars
+Base.view(s::ShapedSolution, i::MatrixIndex) = s.matrices[i.value]

--- a/test/BurerMonteiro.jl
+++ b/test/BurerMonteiro.jl
@@ -182,7 +182,7 @@ end;
     )
     @test model.meta.ncon == 0
     @test LRO.norm_jac(model, LRO.MatrixIndex(1)) == 0
-    @test isnothing(LRO.buffer_for_jtprod(model, LRO.MatrixIndex(1)))
+    @test LRO.buffer_for_jtprod(model, LRO.MatrixIndex(1)) isa LRO.FillArrays.Zeros
 end;
 
 @testset "Fallback" begin

--- a/test/BurerMonteiro.jl
+++ b/test/BurerMonteiro.jl
@@ -182,7 +182,8 @@ end;
     )
     @test model.meta.ncon == 0
     @test LRO.norm_jac(model, LRO.MatrixIndex(1)) == 0
-    @test LRO.buffer_for_jtprod(model, LRO.MatrixIndex(1)) isa LRO.FillArrays.Zeros
+    @test LRO.buffer_for_jtprod(model, LRO.MatrixIndex(1)) isa
+          LRO.FillArrays.Zeros
 end;
 
 @testset "Fallback" begin

--- a/test/buffer.jl
+++ b/test/buffer.jl
@@ -55,7 +55,8 @@ end
 
 function test_zero_Ai()
     @testset "all_zero=$all_zero" for all_zero in [false, true]
-        @testset "matrix_in_objective=$matrix_in_objective" for matrix_in_objective in [false, true]
+        @testset "matrix_in_objective=$matrix_in_objective" for matrix_in_objective in
+                                                                [false, true]
             _test_zero_Ai(all_zero, matrix_in_objective)
         end
     end

--- a/test/buffer.jl
+++ b/test/buffer.jl
@@ -29,6 +29,9 @@ function test_zero_Ai()
     for A in b.model.A
         @test buf.jtprod_buffer[] !== A
     end
+    for κ in 0:5
+        schur_test(model, κ)
+    end
 end
 
 function runtests()

--- a/test/buffer.jl
+++ b/test/buffer.jl
@@ -21,6 +21,7 @@ function _test_zero_Ai(all_zero::Bool)
     b = _backend(model)
     T = Float64
     Z = FillArrays.Zeros{T,2,Tuple{Base.OneTo{Int},Base.OneTo{Int}}}
+    @test b.model.C isa Vector{Z}
     if all_zero
         @test b.model.A isa Matrix{Z}
     else

--- a/test/buffer.jl
+++ b/test/buffer.jl
@@ -1,0 +1,46 @@
+module TestBuffer
+
+import FillArrays, SparseArrays
+using JuMP, Dualization
+include("diff_check.jl")
+
+# Test with zero Ai matrices
+function test_zero_Ai()
+    model = Model(dual_optimizer(LRO.Optimizer))
+    @variable(model, x[1:2] in MOI.Nonnegatives(2))
+    @variable(model, X[1:2, 1:2] in PSDCone())
+    @constraint(model, sum(x) == 1)
+    @constraint(model, 2sum(x) == 2)
+    @constraint(model, sum(X) == 2)
+    @constraint(model, x[1] - x[2] == 1)
+    @objective(model, Max, x[1])
+    set_attribute(model, "solver", ConvexSolver)
+    optimize!(model)
+    b = _backend(model)
+    T = Float64
+    Z = FillArrays.Zeros{T,2,Tuple{Base.OneTo{Int},Base.OneTo{Int}}}
+    S = SparseArrays.SparseMatrixCSC{T,Int}
+    @test b.model.A isa Matrix{Union{Z,S}}
+    @test b.model.A[1] isa Z
+    @test b.model.A[2] isa Z
+    @test b.model.A[3] isa S
+    @test b.model.A[4] isa Z
+    buf = LRO.BufferedModelForSchur(b.model, 1)
+    for A in b.model.A
+        @test buf.jtprod_buffer[] !== A
+    end
+end
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$name", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+end
+
+end
+
+TestBuffer.runtests()

--- a/test/diff_check.jl
+++ b/test/diff_check.jl
@@ -5,6 +5,7 @@
 
 using Test
 using LinearAlgebra
+using FillArrays
 import SolverCore
 using Dualization
 import LowRankOpt as LRO

--- a/test/diff_check.jl
+++ b/test/diff_check.jl
@@ -164,8 +164,11 @@ function schur_test(model::LRO.BufferedModelForSchur{T}, w) where {T}
         ret = LRO.jtprod!(model, y, i)
         @test ret === model.jtprod_buffer[i.value]
         ret = LRO.dual_cons!(model, y, i)
-        @test ret isa SparseArrays.SparseMatrixCSC
-        @test ret !== model.model.C[i.value]
+        if ret isa SparseArrays.SparseMatrixCSC
+            @test ret !== model.model.C[i.value]
+        else
+            @test ret isa FillArrays.Zeros
+        end
     end
     dcons = ones(LRO.num_scalars(model))
     LRO.dual_cons!(model, y, dcons, LRO.ScalarIndex)

--- a/test/maxcut.jl
+++ b/test/maxcut.jl
@@ -54,7 +54,7 @@ function test_maxcut(; is_dual, sparse, vector)
         @test lro_model.A isa Matrix{LowRankOpt.Factorization{Float64,F,D}}
     else
         lro_model = unsafe_backend(model).model
-        @test lro_model.C isa Vector{SparseMatrixCSC{T,Int64}}
+        @test lro_model.C isa Vector{FillArrays.Zeros{T,2,Tuple{Base.OneTo{Int},Base.OneTo{Int}}}}
         @test lro_model.A isa Matrix{SparseMatrixCSC{T,Int64}}
         solver = unsafe_backend(model).solver
         LRO.BurerMonteiro.set_rank!(solver.model, LRO.MatrixIndex(1), 4)

--- a/test/maxcut.jl
+++ b/test/maxcut.jl
@@ -84,69 +84,6 @@ end
     end
 end;
 
-struct ConvexSolver{T} <: SolverCore.AbstractOptimizationSolver
-    model::LRO.Model{T}
-    stats::SolverCore.GenericExecutionStats{T,Vector{T},Vector{T},Any}
-end
-
-function ConvexSolver(model::LRO.Model)
-    stats = SolverCore.GenericExecutionStats(model)
-    return ConvexSolver(model, stats)
-end
-
-function LRO.MOI.get(solver::ConvexSolver, ::LRO.Solution)
-    return LRO.VectorizedSolution(solver.stats.solution, solver.model.dim)
-end
-
-function SolverCore.solve!(::ConvexSolver, ::LRO.Model)
-    return
-end
-
-function _alloc_schur_complement(model, i, Wi, H)
-    if VERSION < v"1.11"
-        return
-    end
-    LRO.add_schur_complement!(model, i, Wi, H)
-    @test 0 == @allocated LRO.add_schur_complement!(model, i, Wi, H)
-end
-
-function schur_test(model::LRO.BufferedModelForSchur{T}, w) where {T}
-    n = model.meta.ncon
-    y = rand(T, n)
-
-    Jv = similar(y)
-    vJ = similar(w)
-    NLPModels.jprod!(model, w, w, Jv)
-    NLPModels.jtprod!(model, w, y, vJ)
-    @test dot(Jv, y) ≈ dot(vJ, w)
-
-    H = zeros(n, n)
-    H = LRO.schur_complement!(model, w, H)
-    Hy = similar(y)
-    LRO.eval_schur_complement!(model, w, y, Hy)
-    @test Hy ≈ H * y
-    for i in LRO.matrix_indices(model)
-        Wi = @inferred w[i]
-        _alloc_schur_complement(model, i, Wi, H)
-    end
-    for i in LRO.matrix_indices(model)
-        ret = LRO.dual_cons!(model, y, i)
-        @test ret isa SparseMatrixCSC
-    end
-    dcons = ones(LRO.num_scalars(model))
-    LRO.dual_cons!(model, y, dcons, LRO.ScalarIndex)
-    @test dcons ≈ model.model.d_lin - model.model.C_lin' * y
-end
-
-function schur_test(model::LRO.Model{T}, κ) where {T}
-    w = rand(T, model.meta.nvar)
-    W = LRO.VectorizedSolution(w, model.dim)
-    for i in LRO.matrix_indices(model)
-        W[i] .= W[i] .+ W[i]'
-    end
-    return schur_test(LRO.BufferedModelForSchur(model, κ), W)
-end
-
 @testset "ConvexSolver $T" for T in [Float32, Float64]
     model = maxcut(T.(weights), LRO.Optimizer{T})
     set_attribute(model, "solver", ConvexSolver)

--- a/test/maxcut.jl
+++ b/test/maxcut.jl
@@ -54,7 +54,9 @@ function test_maxcut(; is_dual, sparse, vector)
         @test lro_model.A isa Matrix{LowRankOpt.Factorization{Float64,F,D}}
     else
         lro_model = unsafe_backend(model).model
-        @test lro_model.C isa Vector{FillArrays.Zeros{T,2,Tuple{Base.OneTo{Int},Base.OneTo{Int}}}}
+        @test lro_model.C isa Vector{
+            FillArrays.Zeros{T,2,Tuple{Base.OneTo{Int},Base.OneTo{Int}}},
+        }
         @test lro_model.A isa Matrix{SparseMatrixCSC{T,Int64}}
         solver = unsafe_backend(model).solver
         LRO.BurerMonteiro.set_rank!(solver.model, LRO.MatrixIndex(1), 4)

--- a/test/maxcut.jl
+++ b/test/maxcut.jl
@@ -3,6 +3,8 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+import Percival
+
 include("diff_check.jl")
 include(joinpath(dirname(@__DIR__), "examples", "maxcut.jl"))
 


### PR DESCRIPTION
This simplifies the use of LowRankOpt for solvers like Loraine. They don't have to deal with the buffers, they can just use the buffered model.