### PR TITLE
Rename to unsafe when a function returns an alias

### DIFF
--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -201,7 +201,7 @@ function NLPModels.jtprod!(
 )
     jtprod!(model, y, vJ[ScalarIndex], ScalarIndex)
     for mat_idx in matrix_indices(model)
-        vJ[mat_idx] .= jtprod!(model, y, mat_idx)
+        vJ[mat_idx] .= unsafe_jtprod(model, y, mat_idx)
     end
 end
 
@@ -248,7 +248,7 @@ function unsafe_jtprod(model::BufferedModelForSchur, y, i::MatrixIndex)
     buffer = model.jtprod_buffer[i.value]
     _zero!(buffer)
     for j in eachindex(y)
-        _add_mul!(buffer, model.A[i.value, j], y[j])
+        _add_mul!(buffer, model.model.A[i.value, j], y[j])
     end
     return buffer
 end
@@ -293,5 +293,5 @@ function unsafe_dual_cons(
     y::AbstractVector,
     i::MatrixIndex,
 )
-    return _sub(model.model.C[i.value], jtprod!(model, y, i))
+    return _sub(model.model.C[i.value], unsafe_jtprod(model, y, i))
 end

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -228,22 +228,29 @@ function _add_mul!(
             while SparseArrays.rowvals(A)[it_A[1]] < row_B
                 it_A = iterate(range_A, it_A[2])
             end
+            # By construction, since we constructed `A` with `_merge_sparsity`
             @assert row_B == SparseArrays.rowvals(A)[it_A[1]]
             SparseArrays.nonzeros(A)[it_A[1]] += SparseArrays.nonzeros(B)[k] * α
         end
     end
 end
 
-function jtprod!(model::Model, y, buffer, mat_idx::MatrixIndex)
+"""
+    unsafe_jtprod(model::BufferedModelForSchur, y, i::MatrixIndex)
+
+Return the product between the sub-Jacobian associated to `i` and `y`:
+`∑ⱼ Aᵢⱼ yⱼ`. This function is **unsafe** because it returns
+an alias to an internal buffer `model.jtprod_buffer[i.value]` that is
+going to be reused whenever `unsafe_jprod` or `unsafe_dual_cons` is called
+is called for the same `i`.
+"""
+function unsafe_jtprod(model::BufferedModelForSchur, y, i::MatrixIndex)
+    buffer = model.jtprod_buffer[i.value]
     _zero!(buffer)
     for j in eachindex(y)
-        _add_mul!(buffer, model.A[mat_idx.value, j], y[j])
+        _add_mul!(buffer, model.A[i.value, j], y[j])
     end
     return buffer
-end
-
-function jtprod!(model::BufferedModelForSchur, y, mat_idx::MatrixIndex)
-    return jtprod!(model.model, y, model.jtprod_buffer[mat_idx.value], mat_idx)
 end
 
 function dual_cons!(
@@ -260,11 +267,28 @@ end
 
 # Note that we can't use `-` because of https://github.com/JuliaArrays/FillArrays.jl/issues/412
 _sub(A::FillArrays.Zeros, ::FillArrays.Zeros) = A
-_sub(A::AbstractArray, ::FillArrays.Zeros) = copy(A)
-_sub(::FillArrays.Zeros, B::AbstractArray) = -B
+# /!\ We don't copy, we warn about it in the docstring.
+_sub(A::AbstractArray, ::FillArrays.Zeros) = A
+function _sub(::FillArrays.Zeros, B::AbstractArray{T}) where {T}
+    # `B` is an alias to an entry of `jtprod_buffer`
+    # so it is safe to modify.
+    # The fact that we may return an alias to this matrix
+    # since we don't copy is warned in the docstring/`
+    LinearAlgebra.rmul!(B, -one(T))
+    return B
+end
 _sub(A::AbstractArray, B::AbstractArray) = A - B
 
-function dual_cons!(
+"""
+    unsafe_dual_cons(model::BufferedModelForSchur, y, i::MatrixIndex)
+
+Return value of the dual constraint of index `i`:
+`C - ∑ⱼ Aᵢⱼ yⱼ`. This function is **unsafe** because it may return
+an alias to the matrix `C` or the internal buffer
+`model.jtprod_buffer[i.value]`. So throw away the reference after using
+the returned value and don't call any mutating operation on it.
+"""
+function unsafe_dual_cons(
     model::BufferedModelForSchur,
     y::AbstractVector,
     i::MatrixIndex,

--- a/src/schur.jl
+++ b/src/schur.jl
@@ -179,7 +179,7 @@ end
 function eval_schur_complement!(model::BufferedModelForSchur, W, y, result)
     fill!(result, zero(eltype(result)))
     for i in matrix_indices(model)
-        add_jprod!(model, W[i] * jtprod!(model, y, i) * W[i], result, i)
+        add_jprod!(model, W[i] * unsafe_jtprod(model, y, i) * W[i], result, i)
     end
     result .+= model.model.C_lin * (W[ScalarIndex] .* (model.model.C_lin' * y))
     return result

--- a/test/diff_check.jl
+++ b/test/diff_check.jl
@@ -162,9 +162,9 @@ function schur_test(model::LRO.BufferedModelForSchur{T}, w) where {T}
     for i in LRO.matrix_indices(model)
         @test model.jtprod_buffer[i.value] isa
               Union{FillArrays.Zeros,SparseArrays.SparseMatrixCSC}
-        ret = LRO.jtprod!(model, y, i)
+        ret = LRO.unsafe_jtprod(model, y, i)
         @test ret === model.jtprod_buffer[i.value]
-        ret = LRO.dual_cons!(model, y, i)
+        ret = LRO.unsafe_dual_cons(model, y, i)
         if ret isa SparseArrays.SparseMatrixCSC
             @test ret !== model.model.C[i.value]
         else


### PR DESCRIPTION
This might create nasty bugs so it's better to warn