### PR TITLE
Allocation-free jtprod for Burer-Monteiro with low-rank constraints

### DIFF
--- a/perf/holy.jl
+++ b/perf/holy.jl
@@ -1,0 +1,84 @@
+using Dualization
+import SDPLRPlus
+include(joinpath(dirname(@__DIR__), "examples", "holy_model.jl"))
+n = 30
+A = data(n)
+lr = holy_lowrank(A)
+set_optimizer(lr, dual_optimizer(LRO.Optimizer))
+set_attribute(lr, "solver", LRO.BurerMonteiro.Solver)
+set_attribute(lr, "sub_solver", SDPLRPlus.Solver)
+set_attribute(lr, "ranks", [15])
+set_attribute(lr, "maxmajoriter", 0)
+set_attribute(lr, "square_scalars", true)
+optimize!(lr)
+
+solver = unsafe_backend(lr).dual_problem.dual_model.model.optimizer.solver;
+aux = solver.model;
+var = solver.solver.var;
+
+using BenchmarkTools
+import NLPModels
+const BM = LRO.BurerMonteiro
+function jtprod(model, var)
+    x = var.Rt
+    y = view(var.y, 1:model.meta.ncon)
+    Jtv = var.Gt
+    @btime NLPModels.jtprod!($model, $x, $y, $Jtv)
+
+    X = BM.Solution(x, model.dim)
+    JtV = BM.Solution(Jtv, model.dim)
+    @btime BM.jtprod!($model, $X, $y, LRO.left_factor($JtV, LRO.ScalarIndex), LRO.ScalarIndex)
+
+    i = LRO.MatrixIndex(1)
+    @btime BM.add_jtprod!($model, $X[$i], $y, $JtV[$i], $i)
+
+    j = 1
+    res = JtV[i].factor
+    A = LRO.jac(model.model, j, i)
+    B = X[i].factor
+    α = 2y[j]
+    buffer = model.jtprod_buffer[]
+    @btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
+
+    C = LRO._mul_to!(buffer, B', LRO.right_factor(A))
+    C = LRO._rmul_diag!!(C, A.scaling)
+    lA = LRO.left_factor(A)
+    @btime LRO._add_mul!($res, $lA, $C', $α)
+end
+
+jtprod(aux, var)
+
+function jtprod_matrix(model, var)
+    x = var.Rt
+    y = view(var.y, 1:model.meta.ncon)
+    Jtv = var.Gt
+    #@time NLPModels.jtprod!(model, x, y, Jtv)
+    X = @time BM.Solution(x, model.dim)
+    JtV = @time BM.Solution(Jtv, model.dim)
+    #@time BM.jtprod!(model, X, y, LRO.left_factor(JtV, LRO.ScalarIndex), LRO.ScalarIndex)
+    i = LRO.MatrixIndex(1)
+    Xi = @time X[i]
+    JtVi = @time JtV[i]
+    @show length(y)
+    i = LRO.MatrixIndex(1)
+    #@btime BM.add_jtprod!($model, $X[i], $y, $JtV[i], $i)
+    j = 1
+    res = JtVi.factor
+    A = @time LRO.jac(model.model, j, i)
+    B = Xi.factor
+    α = 2y[j]
+    buffer = model.jtprod_buffer[]
+    #@edit LinearAlgebra.mul!(res, A, B, α, true)
+    #@profview for i in 1:1000_000
+    #    LRO.buffered_mul!(res, A, B, α, true, buffer)
+    #end
+    @btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
+    #@btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
+
+    C = LRO._mul_to!(buffer, B', LRO.right_factor(A))
+    C = LRO._rmul_diag!!(C, A.scaling)
+    lA = LRO.left_factor(A)
+    #@code_native LRO._add_mul!(res, lA, C', α)
+    @btime LRO._add_mul!($res, $lA, $C', $α)
+end
+jtprod_matrix(aux, var);

--- a/perf/holy.jl
+++ b/perf/holy.jl
@@ -27,7 +27,13 @@ function jtprod(model, var)
 
     X = BM.Solution(x, model.dim)
     JtV = BM.Solution(Jtv, model.dim)
-    @btime BM.jtprod!($model, $X, $y, LRO.left_factor($JtV, LRO.ScalarIndex), LRO.ScalarIndex)
+    @btime BM.jtprod!(
+        $model,
+        $X,
+        $y,
+        LRO.left_factor($JtV, LRO.ScalarIndex),
+        LRO.ScalarIndex,
+    )
 
     i = LRO.MatrixIndex(1)
     @btime BM.add_jtprod!($model, $X[$i], $y, $JtV[$i], $i)
@@ -38,7 +44,13 @@ function jtprod(model, var)
     B = X[i].factor
     α = 2y[j]
     buffer = model.jtprod_buffer[]
-    @btime LRO.buffered_mul!($res, $A, $B, LinearAlgebra.MulAddMul($α, true), $buffer)
+    @btime LRO.buffered_mul!(
+        $res,
+        $A,
+        $B,
+        LinearAlgebra.MulAddMul($α, true),
+        $buffer,
+    )
 
     C = LRO._mul_to!(buffer, B', LRO.right_factor(A))
     C = LRO._rmul_diag!!(C, A.scaling)
@@ -72,7 +84,13 @@ function jtprod_matrix(model, var)
     #@profview for i in 1:1000_000
     #    LRO.buffered_mul!(res, A, B, α, true, buffer)
     #end
-    @btime LRO.buffered_mul!($res, $A, $B, LinearAlgebra.MulAddMul($α, true), $buffer)
+    @btime LRO.buffered_mul!(
+        $res,
+        $A,
+        $B,
+        LinearAlgebra.MulAddMul($α, true),
+        $buffer,
+    )
     #@btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
 
     C = LRO._mul_to!(buffer, B', LRO.right_factor(A))

--- a/perf/holy.jl
+++ b/perf/holy.jl
@@ -48,7 +48,8 @@ function jtprod(model, var)
         $res,
         $A,
         $B,
-        LinearAlgebra.MulAddMul($α, true),
+        $α,
+        true,
         $buffer,
     )
 
@@ -88,7 +89,8 @@ function jtprod_matrix(model, var)
         $res,
         $A,
         $B,
-        LinearAlgebra.MulAddMul($α, true),
+        $α,
+        true,
         $buffer,
     )
     #@btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)

--- a/perf/holy.jl
+++ b/perf/holy.jl
@@ -19,14 +19,25 @@ var = solver.solver.var;
 using BenchmarkTools
 import NLPModels
 const BM = LRO.BurerMonteiro
+
+function _jtprod(model, var)
+    C = LRO._mul_to!(buffer, B', LRO.right_factor(A))
+    C = LRO._rmul_diag!!(C, A.scaling)
+    lA = LRO.left_factor(A)
+    println("_add_mul!")
+    @btime LRO._add_mul!($res, $lA, $C', $α)
+end
+
 function jtprod(model, var)
     x = var.Rt
     y = view(var.y, 1:model.meta.ncon)
     Jtv = var.Gt
+    println("jtprod!")
     @btime NLPModels.jtprod!($model, $x, $y, $Jtv)
 
     X = BM.Solution(x, model.dim)
     JtV = BM.Solution(Jtv, model.dim)
+    println("Scalar jtprod!")
     @btime BM.jtprod!(
         $model,
         $X,
@@ -36,6 +47,7 @@ function jtprod(model, var)
     )
 
     i = LRO.MatrixIndex(1)
+    println("Matrix jtprod!")
     @btime BM.add_jtprod!($model, $X[$i], $y, $JtV[$i], $i)
 
     j = 1
@@ -44,47 +56,8 @@ function jtprod(model, var)
     B = X[i].factor
     α = 2y[j]
     buffer = model.jtprod_buffer[]
+    println("buffered_mul!")
     @btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
-
-    C = LRO._mul_to!(buffer, B', LRO.right_factor(A))
-    C = LRO._rmul_diag!!(C, A.scaling)
-    lA = LRO.left_factor(A)
-    @btime LRO._add_mul!($res, $lA, $C', $α)
 end
 
 jtprod(aux, var)
-
-function jtprod_matrix(model, var)
-    x = var.Rt
-    y = view(var.y, 1:model.meta.ncon)
-    Jtv = var.Gt
-    #@time NLPModels.jtprod!(model, x, y, Jtv)
-    X = @time BM.Solution(x, model.dim)
-    JtV = @time BM.Solution(Jtv, model.dim)
-    #@time BM.jtprod!(model, X, y, LRO.left_factor(JtV, LRO.ScalarIndex), LRO.ScalarIndex)
-    i = LRO.MatrixIndex(1)
-    Xi = @time X[i]
-    JtVi = @time JtV[i]
-    @show length(y)
-    i = LRO.MatrixIndex(1)
-    #@btime BM.add_jtprod!($model, $X[i], $y, $JtV[i], $i)
-    j = 1
-    res = JtVi.factor
-    A = @time LRO.jac(model.model, j, i)
-    B = Xi.factor
-    α = 2y[j]
-    buffer = model.jtprod_buffer[]
-    #@edit LinearAlgebra.mul!(res, A, B, α, true)
-    #@profview for i in 1:1000_000
-    #    LRO.buffered_mul!(res, A, B, α, true, buffer)
-    #end
-    @btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
-    #@btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
-
-    C = LRO._mul_to!(buffer, B', LRO.right_factor(A))
-    C = LRO._rmul_diag!!(C, A.scaling)
-    lA = LRO.left_factor(A)
-    #@code_native LRO._add_mul!(res, lA, C', α)
-    @btime LRO._add_mul!($res, $lA, $C', $α)
-end
-jtprod_matrix(aux, var);

--- a/perf/holy.jl
+++ b/perf/holy.jl
@@ -44,14 +44,7 @@ function jtprod(model, var)
     B = X[i].factor
     α = 2y[j]
     buffer = model.jtprod_buffer[]
-    @btime LRO.buffered_mul!(
-        $res,
-        $A,
-        $B,
-        $α,
-        true,
-        $buffer,
-    )
+    @btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
 
     C = LRO._mul_to!(buffer, B', LRO.right_factor(A))
     C = LRO._rmul_diag!!(C, A.scaling)
@@ -85,14 +78,7 @@ function jtprod_matrix(model, var)
     #@profview for i in 1:1000_000
     #    LRO.buffered_mul!(res, A, B, α, true, buffer)
     #end
-    @btime LRO.buffered_mul!(
-        $res,
-        $A,
-        $B,
-        $α,
-        true,
-        $buffer,
-    )
+    @btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
     #@btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
 
     C = LRO._mul_to!(buffer, B', LRO.right_factor(A))

--- a/perf/holy.jl
+++ b/perf/holy.jl
@@ -38,7 +38,7 @@ function jtprod(model, var)
     B = X[i].factor
     α = 2y[j]
     buffer = model.jtprod_buffer[]
-    @btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
+    @btime LRO.buffered_mul!($res, $A, $B, LinearAlgebra.MulAddMul($α, true), $buffer)
 
     C = LRO._mul_to!(buffer, B', LRO.right_factor(A))
     C = LRO._rmul_diag!!(C, A.scaling)
@@ -72,7 +72,7 @@ function jtprod_matrix(model, var)
     #@profview for i in 1:1000_000
     #    LRO.buffered_mul!(res, A, B, α, true, buffer)
     #end
-    @btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
+    @btime LRO.buffered_mul!($res, $A, $B, LinearAlgebra.MulAddMul($α, true), $buffer)
     #@btime LRO.buffered_mul!($res, $A, $B, $α, true, $buffer)
 
     C = LRO._mul_to!(buffer, B', LRO.right_factor(A))

--- a/perf/maxcut.jl
+++ b/perf/maxcut.jl
@@ -42,7 +42,12 @@ function bench_rmul(A)
     x = rand(n, 1)
     y = similar(x)
     println("rmul")
-    @btime LinearAlgebra.mul!($y, $A, $x, 2.0, 1.0)
+    if A.factor isa AbstractVector
+        buffer = zeros(1)
+    else
+        buffer = zeros(1, LRO.max_rank(A))
+    end
+    @btime LRO.buffered_mul!($y, $A, $x, 2.0, 1.0, $buffer)
 end
 
 function bench(aux, var)
@@ -71,6 +76,7 @@ function bench_plus(args...; kws...)
 end
 
 function bench_lro(args...; vector, kws...)
+    println("vector ? $vector")
     model = maxcut(weights(args...; kws...), dual_optimizer(LRO.Optimizer); vector)
     set_attribute(model, "solver", LRO.BurerMonteiro.Solver)
     set_attribute(model, "sub_solver", SDPLRPlus.Solver)
@@ -89,5 +95,4 @@ n = 500
 p = 0.1
 bench_plus(n; p)
 bench_lro(n; p, vector = true)
-bench_lro(n; p, vector = false)
 bench_lro(n; p, vector = false)

--- a/perf/set_dot.jl
+++ b/perf/set_dot.jl
@@ -1,5 +1,7 @@
 include(joinpath(dirname(@__DIR__), "examples", "maxcut.jl"))
 
+using BenchmarkTools
+
 # Important for Dualization
 function bench_set_dot(n)
     T = Float64

--- a/src/BurerMonteiro/model.jl
+++ b/src/BurerMonteiro/model.jl
@@ -294,14 +294,11 @@ function NLPModels.hprod!(
         obj_weight,
     )
     for i in LRO.matrix_indices(model.model)
-        Vi = V[i].factor
+        Vi = V[i]
         C = LRO.grad(model.model, i)
-        Hvi = HV[i].factor
-        LinearAlgebra.mul!(Hvi, C, Vi, 2obj_weight, false)
-        for j in 1:model.meta.ncon
-            A = LRO.jac(model.model, j, i)
-            LinearAlgebra.mul!(Hvi, A, Vi, -2y[j], true)
-        end
+        Hvi = HV[i]
+        LinearAlgebra.mul!(Hvi.factor, C, Vi.factor, 2obj_weight, false)
+        add_jtprod!(model, Vi, y, Hvi, i, -2)
     end
     return Hv
 end

--- a/src/BurerMonteiro/model.jl
+++ b/src/BurerMonteiro/model.jl
@@ -75,7 +75,8 @@ function grad!(
     i::LRO.MatrixIndex,
 )
     C = LRO.grad(model.model, i)
-    buffer = _buffer(model.jtprod_buffer[i.value], LRO.right_factor(C), X.factor)
+    buffer =
+        _buffer(model.jtprod_buffer[i.value], LRO.right_factor(C), X.factor)
     LRO.buffered_mul!(G.factor, C, X.factor, true, false, buffer)
     G.factor .*= 2
     return
@@ -157,7 +158,11 @@ function jtprod!(
     return JtV
 end
 
-function buffer_for_jtprod(model::LRO.Model{T}, dim::Dimensions, i::LRO.MatrixIndex) where {T}
+function buffer_for_jtprod(
+    model::LRO.Model{T},
+    dim::Dimensions,
+    i::LRO.MatrixIndex,
+) where {T}
     row = view(model.A, i.value, :)
     if any(A -> A isa LRO.AbstractFactorization{T,<:AbstractMatrix}, row)
         error("TODO")

--- a/src/BurerMonteiro/model.jl
+++ b/src/BurerMonteiro/model.jl
@@ -76,7 +76,7 @@ function grad!(
 )
     C = LRO.grad(model.model, i)
     buffer = _buffer(model.jtprod_buffer[i.value], C, X.factor)
-    LRO.buffered_mul!(G.factor, C, X.factor, true, false, buffer)
+    LRO.buffered_mul!(G.factor, C, X.factor, LinearAlgebra.MulAddMul(true, false), buffer)
     G.factor .*= 2
     return
 end
@@ -205,7 +205,7 @@ function add_jtprod!(
     for j in eachindex(y)
         A = LRO.jac(model.model, j, i)
         buffer = _buffer(model.jtprod_buffer[i.value], A, X.factor)
-        LRO.buffered_mul!(JtV.factor, A, X.factor, α * y[j], true, buffer)
+        LRO.buffered_mul!(JtV.factor, A, X.factor, LinearAlgebra.MulAddMul(α * y[j], true), buffer)
     end
 end
 

--- a/src/BurerMonteiro/model.jl
+++ b/src/BurerMonteiro/model.jl
@@ -307,9 +307,9 @@ function NLPModels.hprod!(
     )
     for i in LRO.matrix_indices(model.model)
         Vi = V[i]
-        C = LRO.grad(model.model, i)
         Hvi = HV[i]
-        LinearAlgebra.mul!(Hvi.factor, C, Vi.factor, 2obj_weight, false)
+        grad!(model, Vi, Hvi, i)
+        Hvi.factor .*= obj_weight
         add_jtprod!(model, Vi, y, Hvi, i, -2)
     end
     return Hv

--- a/src/BurerMonteiro/model.jl
+++ b/src/BurerMonteiro/model.jl
@@ -76,7 +76,13 @@ function grad!(
 )
     C = LRO.grad(model.model, i)
     buffer = _buffer(model.jtprod_buffer[i.value], C, X.factor)
-    LRO.buffered_mul!(G.factor, C, X.factor, LinearAlgebra.MulAddMul(true, false), buffer)
+    LRO.buffered_mul!(
+        G.factor,
+        C,
+        X.factor,
+        LinearAlgebra.MulAddMul(true, false),
+        buffer,
+    )
     G.factor .*= 2
     return
 end
@@ -205,7 +211,13 @@ function add_jtprod!(
     for j in eachindex(y)
         A = LRO.jac(model.model, j, i)
         buffer = _buffer(model.jtprod_buffer[i.value], A, X.factor)
-        LRO.buffered_mul!(JtV.factor, A, X.factor, LinearAlgebra.MulAddMul(α * y[j], true), buffer)
+        LRO.buffered_mul!(
+            JtV.factor,
+            A,
+            X.factor,
+            LinearAlgebra.MulAddMul(α * y[j], true),
+            buffer,
+        )
     end
 end
 

--- a/src/BurerMonteiro/model.jl
+++ b/src/BurerMonteiro/model.jl
@@ -76,14 +76,7 @@ function grad!(
 )
     C = LRO.grad(model.model, i)
     buffer = _buffer(model.jtprod_buffer[i.value], C, X.factor)
-    LRO.buffered_mul!(
-        G.factor,
-        C,
-        X.factor,
-        true,
-        false,
-        buffer,
-    )
+    LRO.buffered_mul!(G.factor, C, X.factor, true, false, buffer)
     G.factor .*= 2
     return
 end
@@ -212,14 +205,7 @@ function add_jtprod!(
     for j in eachindex(y)
         A = LRO.jac(model.model, j, i)
         buffer = _buffer(model.jtprod_buffer[i.value], A, X.factor)
-        LRO.buffered_mul!(
-            JtV.factor,
-            A,
-            X.factor,
-            α * y[j],
-            true,
-            buffer,
-        )
+        LRO.buffered_mul!(JtV.factor, A, X.factor, α * y[j], true, buffer)
     end
 end
 

--- a/src/BurerMonteiro/model.jl
+++ b/src/BurerMonteiro/model.jl
@@ -199,7 +199,7 @@ function _buffer(buffer::AbstractMatrix, A::_LowRank, ::AbstractMatrix)
     #else
     # Using this `view` instead of `buffer`, `AllocCheck` now
     # sees possible allocations but `@allocated` sees none
-    view(buffer, :, Base.OneTo(LRO.max_rank(A)))
+    return view(buffer, :, Base.OneTo(LRO.max_rank(A)))
     #end
 end
 

--- a/src/BurerMonteiro/model.jl
+++ b/src/BurerMonteiro/model.jl
@@ -191,8 +191,17 @@ end
 
 _buffer(_, ::AbstractMatrix, _) = nothing
 _buffer(buffer::AbstractVector, ::_RankOne, ::AbstractMatrix) = buffer
-# TODO check that the size matches, it may not be the highest rank matrix
-_buffer(buffer::AbstractMatrix, ::_LowRank, ::AbstractMatrix) = buffer
+function _buffer(buffer::AbstractMatrix, A::_LowRank, ::AbstractMatrix)
+    # FIXME with this if-else, we return a small Union but the compiler
+    #       since to forget about this Union and allocates later
+    #if size(buffer, 2) == LRO.max_rank(A)
+    #    buffer
+    #else
+    # Using this `view` instead of `buffer`, `AllocCheck` now
+    # sees possible allocations but `@allocated` sees none
+    view(buffer, :, Base.OneTo(LRO.max_rank(A)))
+    #end
+end
 
 function add_jtprod!(
     model::Model,

--- a/src/BurerMonteiro/model.jl
+++ b/src/BurerMonteiro/model.jl
@@ -80,7 +80,8 @@ function grad!(
         G.factor,
         C,
         X.factor,
-        LinearAlgebra.MulAddMul(true, false),
+        true,
+        false,
         buffer,
     )
     G.factor .*= 2
@@ -215,7 +216,8 @@ function add_jtprod!(
             JtV.factor,
             A,
             X.factor,
-            LinearAlgebra.MulAddMul(α * y[j], true),
+            α * y[j],
+            true,
             buffer,
         )
     end

--- a/src/BurerMonteiro/solution.jl
+++ b/src/BurerMonteiro/solution.jl
@@ -15,6 +15,8 @@ function Dimensions{S}(model::LRO.Model, ranks) where {S}
     return Dimensions{S}(num_scalars, side_dimensions, ranks, offsets)
 end
 
+Base.broadcastable(d::Dimensions) = Ref(d)
+
 Base.length(d::Dimensions) = d.offsets[end]
 
 function set_rank!(d::Dimensions, i::LRO.MatrixIndex, rank)

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -518,7 +518,7 @@ function LinearAlgebra.mul!(
     ::Number,
     ::Number,
 )
-    error("This is inefficient, call `buffered_mul!` instead")
+    return error("This is inefficient, call `buffered_mul!` instead")
 end
 
 function LinearAlgebra.mul!(
@@ -528,5 +528,5 @@ function LinearAlgebra.mul!(
     ::Number,
     ::Number,
 )
-    error("This is inefficient, call `buffered_mul!` instead")
+    return error("This is inefficient, call `buffered_mul!` instead")
 end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -479,7 +479,12 @@ end
 # If we took `α` and `β` separately in `buffered_mul!`, because of the few methods before we may call this `LinearAlgebra.mul!`
 # again, the compiler might fail to do constant propagation and then allocate when building `MulAddMul` as it is type unstable.
 # This is the reason we pass around a `MulAddMul that we then dismantle here.
-function _mul!(res::AbstractVecOrMat, A::AbstractVecOrMat, B, _add::LinearAlgebra.MulAddMul)
+function _mul!(
+    res::AbstractVecOrMat,
+    A::AbstractVecOrMat,
+    B,
+    _add::LinearAlgebra.MulAddMul,
+)
     return LinearAlgebra.mul!(res, A, B, _add.alpha, _add.beta)
 end
 

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -396,17 +396,16 @@ function _mul!(
     A::SparseArrays.AbstractSparseArray,
     B,
     _add::LinearAlgebra.MulAddMul,
-    β,
 ) where {T}
-    if iszero(_add.β) # TODO Could actually dispatch on the type of MulAddMul
+    if iszero(_add.beta) # TODO Could actually dispatch on the type of MulAddMul
         # Since `A` is sparse, there may be some entries of `res` that we won't touch so
         # we cannot use `LinearAlgebra.MulAddMul(α, β)` as it won't set them to zero.
         # It's better to just set them to zero now and then use `_add_mul!`.
         fill!(res, zero(T))
     else
-        @assert isone(β) # TODO Could actually dispatch on the type of MulAddMul to check that it's Bool and true with {_,false,_,Bool}
+        @assert isone(_add.beta) # TODO Could actually dispatch on the type of MulAddMul to check that it's Bool and true with {_,false,_,Bool}
     end
-    return _add_mul!(res, A, B, _add.α)
+    return _add_mul!(res, A, B, _add.alpha)
 end
 
 function _add_mul!(

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -18,6 +18,11 @@ function Base.getindex(m::AbstractFactorization, i::Int, j::Int)
     )
 end
 
+# Structural maximum rank
+function max_rank(m::AbstractFactorization)
+    return size(left_factor(m), 2)
+end
+
 """
     struct Factorization{
         T,

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -472,7 +472,9 @@ function _add_mul!(
     end
 end
 
-function _mul!(res::AbstractVecOrMat, A::AbstractVecOrMat, B, α, β)
+# Without the `@inline`, it allocates on Julia v1.11.6 probably because
+# it decies to not specialize the method
+@inline function _mul!(res::AbstractVecOrMat, A::AbstractVecOrMat, B, α, β)
     return LinearAlgebra.mul!(res, A, B, α, β)
 end
 

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -514,7 +514,7 @@ function buffered_mul!(
     _add::LinearAlgebra.MulAddMul,
     _,
 )
-    return LinearAlgebra.mul!(res, A, B, _add.α, _add.β)
+    return LinearAlgebra.mul!(res, A, B, _add.alpha, _add.beta)
 end
 
 function LinearAlgebra.mul!(

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -478,14 +478,41 @@ end
 
 # If we took `α` and `β` separately in `buffered_mul!`, because of the few methods before we may call this `LinearAlgebra.mul!`
 # again, the compiler might fail to do constant propagation and then allocate when building `MulAddMul` as it is type unstable.
-# This is the reason we pass around a `MulAddMul that we then dismantle here.
-function _mul!(
-    res::AbstractVecOrMat,
+# If we call `LinearAlgebra.mul!`, we'll have to dismantle it and rebuild it so we directly call `generic_matmatmul!`
+# We unfortunately miss many specialized methods like the ones for `Diagonal` matrices or the ones that could be define in separate packages :/
+# And we need to distinguish between `matmat` and `matvec` ourself
+
+_mul!(C, A, B, _add) = _generic_mul!(C, A, B, _add)
+
+function _generic_mul!(
+    C::AbstractMatrix,
     A::AbstractVecOrMat,
-    B,
+    B::AbstractVecOrMat,
     _add::LinearAlgebra.MulAddMul,
 )
-    return LinearAlgebra.mul!(res, A, B, _add.alpha, _add.beta)
+    return LinearAlgebra.generic_matmatmul!(
+        C,
+        LinearAlgebra.wrapper_char(A),
+        LinearAlgebra.wrapper_char(B),
+        LinearAlgebra._unwrap(A),
+        LinearAlgebra._unwrap(B),
+        _add,
+    )
+end
+
+function _generic_mul!(
+    C::AbstractVector,
+    A::AbstractVecOrMat,
+    B::AbstractVector,
+    _add::LinearAlgebra.MulAddMul,
+)
+    return LinearAlgebra.generic_matvecmul!(
+        C,
+        LinearAlgebra.wrapper_char(A),
+        LinearAlgebra._unwrap(A),
+        B,
+        _add,
+    )
 end
 
 _mul_to!(::Nothing, A, B) = A * B

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -485,13 +485,8 @@ end
 
 _mul!(C, A, B, _add) = _generic_mul!(C, A, B, _add)
 
-function _generic_mul!(
-    C,
-    A,
-    B,
-    _add,
-)
-    LinearAlgebra._rscale_add!(C, A, B, _add.alpha, _add.beta)
+function _generic_mul!(C, A, B, _add)
+    return LinearAlgebra._rscale_add!(C, A, B, _add.alpha, _add.beta)
 end
 
 function _generic_mul!(

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -478,41 +478,14 @@ end
 
 # If we took `α` and `β` separately in `buffered_mul!`, because of the few methods before we may call this `LinearAlgebra.mul!`
 # again, the compiler might fail to do constant propagation and then allocate when building `MulAddMul` as it is type unstable.
-# If we call `LinearAlgebra.mul!`, we'll have to dismantle it and rebuild it so we directly call `generic_matmatmul!`
-# We unfortunately miss many specialized methods like the ones for `Diagonal` matrices or the ones that could be define in separate packages :/
-# And we need to distinguish between `matmat` and `matvec` ourself
-
-_mul!(C, A, B, _add) = _generic_mul!(C, A, B, _add)
-
-function _generic_mul!(
-    C::AbstractMatrix,
+# This is the reason we pass around a `MulAddMul that we then dismantle here.
+function _mul!(
+    res::AbstractVecOrMat,
     A::AbstractVecOrMat,
-    B::AbstractVecOrMat,
+    B,
     _add::LinearAlgebra.MulAddMul,
 )
-    return LinearAlgebra.generic_matmatmul!(
-        C,
-        LinearAlgebra.wrapper_char(A),
-        LinearAlgebra.wrapper_char(B),
-        LinearAlgebra._unwrap(A),
-        LinearAlgebra._unwrap(B),
-        _add,
-    )
-end
-
-function _generic_mul!(
-    C::AbstractVector,
-    A::AbstractVecOrMat,
-    B::AbstractVector,
-    _add::LinearAlgebra.MulAddMul,
-)
-    return LinearAlgebra.generic_matvecmul!(
-        C,
-        LinearAlgebra.wrapper_char(A),
-        LinearAlgebra._unwrap(A),
-        B,
-        _add,
-    )
+    return LinearAlgebra.mul!(res, A, B, _add.alpha, _add.beta)
 end
 
 _mul_to!(::Nothing, A, B) = A * B

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -395,17 +395,18 @@ function _mul!(
     res::AbstractVecOrMat{T},
     A::SparseArrays.AbstractSparseArray,
     B,
-    _add::LinearAlgebra.MulAddMul,
+    α,
+    β,
 ) where {T}
-    if iszero(_add.beta) # TODO Could actually dispatch on the type of MulAddMul
+    if iszero(β)
         # Since `A` is sparse, there may be some entries of `res` that we won't touch so
         # we cannot use `LinearAlgebra.MulAddMul(α, β)` as it won't set them to zero.
         # It's better to just set them to zero now and then use `_add_mul!`.
         fill!(res, zero(T))
     else
-        @assert isone(_add.beta) # TODO Could actually dispatch on the type of MulAddMul to check that it's Bool and true with {_,false,_,Bool}
+        @assert isone(β)
     end
-    return _add_mul!(res, A, B, _add.alpha)
+    return _add_mul!(res, A, B, α)
 end
 
 function _add_mul!(
@@ -476,58 +477,25 @@ function _add_mul!(
     end
 end
 
-# If we took `α` and `β` separately in `buffered_mul!`, because of the few methods before we may call this `LinearAlgebra.mul!`
-# again, the compiler might fail to do constant propagation and then allocate when building `MulAddMul` as it is type unstable.
-# If we call `LinearAlgebra.mul!`, we'll have to dismantle it and rebuild it so we directly call `generic_matmatmul!`
-# We unfortunately miss many specialized methods like the ones for `Diagonal` matrices or the ones that could be define in separate packages :/
-# We assert that we have strided arrays to be warned if we missed one (e.g. if we have a `FillArrays.Zeros`)
-# And we need to distinguish between `matmat` and `matvec` ourself
-
-_mul!(C, A, B, _add) = _generic_mul!(C, A, B, _add)
-
-function _generic_mul!(C, A, B, _add)
-    return LinearAlgebra._rscale_add!(C, A, B, _add.alpha, _add.beta)
-end
-
-function _generic_mul!(
-    C::StridedMatrix,
-    A::AbstractVecOrMat,
-    B::AbstractVecOrMat,
-    _add::LinearAlgebra.MulAddMul,
-)
-    return LinearAlgebra.generic_matmatmul!(
-        C,
-        LinearAlgebra.wrapper_char(A),
-        LinearAlgebra.wrapper_char(B),
-        LinearAlgebra._unwrap(A)::StridedVecOrMat,
-        LinearAlgebra._unwrap(B)::StridedVecOrMat,
-        _add,
-    )
-end
-
-function _generic_mul!(
-    C::AbstractVector,
-    A::AbstractVecOrMat,
-    B::StridedVector,
-    _add::LinearAlgebra.MulAddMul,
-)
-    return LinearAlgebra.generic_matvecmul!(
-        C,
-        LinearAlgebra.wrapper_char(A),
-        LinearAlgebra._unwrap(A)::StridedVecOrMat,
-        B,
-        _add,
-    )
-end
+# `MulAddMul(α, β)` is type unstable as the first two type parameters depends on whether `α` is one
+# and whether `β` is zero.
+# One way to avoid this allocation is to construct it and call the next method within `LinearAlgebra.@stable_muladdmul`
+# which will add if-else clauses.
+# This is however not done when calling `BLAS` since when we call BLAS we just wrap and then unwrap this `MulAddMul`
+# so it should be optimized out and hence not allocation should be incurred due to type instability.
+# For this to work, we need to call `@inline` as suggested by
+# https://github.com/JuliaLang/julia/pull/29634#issuecomment-440512432
+@inline _mul!(C, A, B, α, β) = LinearAlgebra.mul!(C, A, B, α, β)
 
 _mul_to!(::Nothing, A, B) = A * B
 _mul_to!(buffer, A, B) = LinearAlgebra.mul!(buffer, A, B)
 
-function buffered_mul!(
+@inline function buffered_mul!(
     res::AbstractVecOrMat,
     A::AbstractFactorization,
     B::AbstractVecOrMat,
-    _add::LinearAlgebra.MulAddMul,
+    α,
+    β,
     buffer,
 )
     # TODO if `scaling` is `FillArrays.Fill`, we could just update `α`
@@ -538,7 +506,7 @@ function buffered_mul!(
     C = _mul_to!(buffer, B', right_factor(A))
     C = _rmul_diag!!(C, A.scaling)
     lA = left_factor(A)
-    return _mul!(res, lA, C', _add)
+    return _mul!(res, lA, C', α, β)
 end
 
 # We want the same implementation for the two following ones but we can't use
@@ -547,10 +515,11 @@ function buffered_mul!(
     res::AbstractVecOrMat,
     A::AbstractMatrix,
     B::AbstractVecOrMat,
-    _add::LinearAlgebra.MulAddMul,
+    α,
+    β,
     _,
 )
-    return LinearAlgebra.mul!(res, A, B, _add.alpha, _add.beta)
+    return LinearAlgebra.mul!(res, A, B, α, β)
 end
 
 function LinearAlgebra.mul!(

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -480,12 +480,22 @@ end
 # again, the compiler might fail to do constant propagation and then allocate when building `MulAddMul` as it is type unstable.
 # If we call `LinearAlgebra.mul!`, we'll have to dismantle it and rebuild it so we directly call `generic_matmatmul!`
 # We unfortunately miss many specialized methods like the ones for `Diagonal` matrices or the ones that could be define in separate packages :/
+# We assert that we have strided arrays to be warned if we missed one (e.g. if we have a `FillArrays.Zeros`)
 # And we need to distinguish between `matmat` and `matvec` ourself
 
 _mul!(C, A, B, _add) = _generic_mul!(C, A, B, _add)
 
 function _generic_mul!(
-    C::AbstractMatrix,
+    C,
+    A,
+    B,
+    _add,
+)
+    LinearAlgebra._rscale_add!(C, A, B, _add.alpha, _add.beta)
+end
+
+function _generic_mul!(
+    C::StridedMatrix,
     A::AbstractVecOrMat,
     B::AbstractVecOrMat,
     _add::LinearAlgebra.MulAddMul,
@@ -494,8 +504,8 @@ function _generic_mul!(
         C,
         LinearAlgebra.wrapper_char(A),
         LinearAlgebra.wrapper_char(B),
-        LinearAlgebra._unwrap(A),
-        LinearAlgebra._unwrap(B),
+        LinearAlgebra._unwrap(A)::StridedVecOrMat,
+        LinearAlgebra._unwrap(B)::StridedVecOrMat,
         _add,
     )
 end
@@ -503,13 +513,13 @@ end
 function _generic_mul!(
     C::AbstractVector,
     A::AbstractVecOrMat,
-    B::AbstractVector,
+    B::StridedVector,
     _add::LinearAlgebra.MulAddMul,
 )
     return LinearAlgebra.generic_matvecmul!(
         C,
         LinearAlgebra.wrapper_char(A),
-        LinearAlgebra._unwrap(A),
+        LinearAlgebra._unwrap(A)::StridedVecOrMat,
         B,
         _add,
     )

--- a/src/model.jl
+++ b/src/model.jl
@@ -110,9 +110,12 @@ num_scalars(model::Model) = length(model.d_lin)
 
 num_matrices(model::Model) = length(model.C)
 
+# Julia has troubles inferring the return type of constructors
+_matrix_index(i)::MatrixIndex = MatrixIndex(i)
+
 function matrix_indices(model::Union{Model,AbstractSolution})
     return MOI.Utilities.LazyMap{MatrixIndex}(
-        MatrixIndex,
+        _matrix_index,
         Base.OneTo(num_matrices(model)),
     )
 end

--- a/test/BurerMonteiro.jl
+++ b/test/BurerMonteiro.jl
@@ -189,3 +189,31 @@ end;
 @testset "Fallback" begin
     @test LRO.Optimizer() isa LRO.Optimizer{Float64}
 end
+
+@testset "Different factor ranks" begin
+    T = Float64
+    model = Model(LRO.Optimizer)
+    cone = MOI.PositiveSemidefiniteConeTriangle(2)
+    factors = LRO.positive_semidefinite_factorization.(Matrix{T}[T[1 3; 3 1], T[1; 2;;], T[3; 4;;]])
+    tri = LRO.TriangleVectorization.(factors)
+    set = LRO.LinearCombinationInSet{LRO.WITHOUT_SET}(cone, tri)
+    set_attribute(model, "solver", LRO.BurerMonteiro.Solver)
+    set_attribute(model, "sub_solver", Percival.PercivalSolver)
+    set_attribute(model, "ranks", [2])
+    @variable(model, x)
+    @variable(model, y)
+    @constraint(model, [1, -x, -y] in set)
+
+    set_attribute(model, "max_iter", 0)
+    optimize!(model)
+    @test termination_status(model) == MOI.ITERATION_LIMIT
+    diff_check(model)
+    nlp = unsafe_backend(model).model;
+    T = Float64
+    MT = LRO.Factorization{T,Matrix{T},LRO.Ones{T}}
+    @test nlp.C isa Vector{MT}
+    @test nlp.C[] == factors[1]
+    @test nlp.A isa Matrix{MT}
+    @test nlp.A[1] == factors[2]
+    @test nlp.A[2] == factors[3]
+end;

--- a/test/BurerMonteiro.jl
+++ b/test/BurerMonteiro.jl
@@ -194,7 +194,9 @@ end
     T = Float64
     model = Model(LRO.Optimizer)
     cone = MOI.PositiveSemidefiniteConeTriangle(2)
-    factors = LRO.positive_semidefinite_factorization.(Matrix{T}[T[1 3; 3 1], T[1; 2;;], T[3; 4;;]])
+    factors = LRO.positive_semidefinite_factorization.(
+        Matrix{T}[T[1 3; 3 1], T[1; 2;;], T[3; 4;;]],
+    )
     tri = LRO.TriangleVectorization.(factors)
     set = LRO.LinearCombinationInSet{LRO.WITHOUT_SET}(cone, tri)
     set_attribute(model, "solver", LRO.BurerMonteiro.Solver)

--- a/test/diff_check.jl
+++ b/test/diff_check.jl
@@ -6,6 +6,7 @@
 using Test
 using LinearAlgebra
 using FillArrays
+using JuMP
 import SolverCore
 using Dualization
 import LowRankOpt as LRO
@@ -52,6 +53,11 @@ function jac_check(model, x; kws...)
             J';
             kws...,
         )
+        v = rand(length(x))
+        y = rand(model.meta.ncon)
+        # Warmup
+        NLPModels.jtprod!(model, x, y, v)
+        @test 0 == @allocated NLPModels.jtprod!(model, x, y, v)
     end
 end
 
@@ -153,7 +159,7 @@ function schur_test(model::LRO.BufferedModelForSchur{T}, w) where {T}
     vJ = similar(w)
     NLPModels.jprod!(model, w, w, Jv)
     NLPModels.jtprod!(model, w, y, vJ)
-    @test 0 == @inferred NLPModels.jtprod!(model, w, y, vJ)
+    @test 0 == @allocated NLPModels.jtprod!(model, w, y, vJ)
     @test dot(Jv, y) ≈ dot(vJ, w)
 
     H = zeros(n, n)

--- a/test/diff_check.jl
+++ b/test/diff_check.jl
@@ -128,7 +128,12 @@ function schur_test(model::LRO.BufferedModelForSchur{T}, w) where {T}
     n = model.meta.ncon
     y = rand(T, n)
 
-    idx = LRO.matrix_indices(model)
+    idx = @inferred LRO.matrix_indices(model)
+    if !isempty(idx)
+        @inferred first(idx)
+        @inferred idx[1]
+    end
+
     @test NLPModels.obj(model, w) ≈
           dot(LRO.grad(model, LRO.ScalarIndex), w[LRO.ScalarIndex]) +
           dot(LRO.grad.(model, idx), getindex.(Ref(w), idx))
@@ -148,6 +153,7 @@ function schur_test(model::LRO.BufferedModelForSchur{T}, w) where {T}
     vJ = similar(w)
     NLPModels.jprod!(model, w, w, Jv)
     NLPModels.jtprod!(model, w, y, vJ)
+    @test 0 == @inferred NLPModels.jtprod!(model, w, y, vJ)
     @test dot(Jv, y) ≈ dot(vJ, w)
 
     H = zeros(n, n)

--- a/test/factorization.jl
+++ b/test/factorization.jl
@@ -34,8 +34,7 @@ function test_mul_error()
     err = ErrorException(
         "Missing `_add_mul!` between `Vector{Float64}`, `Main.TestSets.DummySparse` and `Float64`",
     )
-    _add = LinearAlgebra.MulAddMul(true, true)
-    @test_throws err LRO.buffered_mul!(rand(2), F, rand(2), _add, nothing)
+    @test_throws err LRO.buffered_mul!(rand(2), F, rand(2), true, true, nothing)
     return
 end
 
@@ -98,8 +97,7 @@ function _test_mul(A, B, α, β)
             end
         end
         @test_throws err LinearAlgebra.mul!(res, A, B, α, β)
-        _add = LinearAlgebra.MulAddMul(α, β)
-        LRO.buffered_mul!(res, A, B, _add, buffer)
+        LRO.buffered_mul!(res, A, B, α, β, buffer)
     else
         LinearAlgebra.mul!(res, A, B, α, β)
     end


### PR DESCRIPTION
I'll post benchmarks before-after once tests pass

## Max-Cut

Before
```
     dataset   majoriter   localiter   totaliter     Lagranval        objval      gradnorm      pvio val  best suboptimality
                      0          -1           0    -1.733e+03    -1.992e+03     1.211e+00     7.168e-01     1.000e+20
  2.966836 seconds (7.79 M allocations: 468.664 MiB, 2.68% gc time, 96.17% compilation time)
𝒜 sym
  30.262 μs (1019 allocations: 39.72 KiB)
𝒜 not sym
  38.635 μs (2017 allocations: 71.00 KiB)
𝒜t
  29.127 μs (1016 allocations: 35.90 KiB)
𝒜t rank-1
  31.200 μs (160 allocations: 94.11 KiB)
rmul
  25.431 ns (2 allocations: 64 bytes)

     dataset   majoriter   localiter   totaliter     Lagranval        objval      gradnorm      pvio val  best suboptimality
                      0          -1           0    -1.733e+03    -1.992e+03     1.211e+00     7.168e-01     1.000e+20
  3.116450 seconds (8.94 M allocations: 525.877 MiB, 2.03% gc time, 93.20% compilation time)
𝒜 sym
  66.000 μs (1019 allocations: 47.53 KiB)
𝒜 not sym
  43.700 μs (2017 allocations: 86.62 KiB)
𝒜t
  65.794 μs (1016 allocations: 43.71 KiB)
𝒜t rank-1
  1.092 ms (1160 allocations: 125.36 KiB)
rmul
  92.649 ns (2 allocations: 80 bytes)
```
After
```
vector ? true
     dataset   majoriter   localiter   totaliter     Lagranval        objval      gradnorm      pvio val  best suboptimality
                      0          -1           0    -1.733e+03    -1.992e+03     1.211e+00     7.168e-01     1.000e+20
  0.052392 seconds (673.70 k allocations: 106.917 MiB)
𝒜 sym
  30.743 μs (1006 allocations: 39.27 KiB)
𝒜 not sym
  39.019 μs (2006 allocations: 70.52 KiB)
𝒜t
  24.194 μs (3 allocations: 4.01 KiB)
𝒜t rank-1
  33.019 μs (176 allocations: 94.61 KiB)
rmul
  10.450 ns (0 allocations: 0 bytes)

vector ? false
     dataset   majoriter   localiter   totaliter     Lagranval        objval      gradnorm      pvio val  best suboptimality
                      0          -1           0    -1.733e+03    -1.992e+03     1.211e+00     7.168e-01     1.000e+20
  0.204001 seconds (798.70 k allocations: 110.811 MiB)
𝒜 sym
  62.910 μs (1006 allocations: 47.08 KiB)
𝒜 not sym
  42.567 μs (2006 allocations: 86.14 KiB)
𝒜t
  35.787 μs (3 allocations: 4.01 KiB)
𝒜t rank-1
  1.173 ms (1176 allocations: 125.89 KiB)
rmul
  14.423 ns (0 allocations: 0 bytes)
```

## Holy

Before
```
jtprod!
  29.459 μs (877 allocations: 75.11 KiB)
Scalar jtprod!
  2.387 μs (0 allocations: 0 bytes)
Matrix jtprod!
  27.458 μs (870 allocations: 74.77 KiB)
buffered_mul!
  59.164 ns (2 allocations: 176 bytes)
```
After
```
jtprod!
  21.779 μs (0 allocations: 0 bytes)
Scalar jtprod!
  2.429 μs (0 allocations: 0 bytes)
Matrix jtprod!
  19.973 μs (0 allocations: 0 bytes)
buffered_mul!
  42.429 ns (0 allocations: 0 bytes)
```